### PR TITLE
Add Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 # command to install dependencies
 install:
   - "pip install . --use-mirrors"

--- a/contrib/sleepycalc/app.py
+++ b/contrib/sleepycalc/app.py
@@ -48,7 +48,8 @@ vs. after the extension:
 
     1000
 """
-from httplib import BAD_REQUEST, OK
+from __future__ import division, unicode_literals
+from six.moves.http_client import BAD_REQUEST, OK
 from time import sleep
 
 from werkzeug.contrib.cache import FileSystemCache

--- a/flask_webcache/__init__.py
+++ b/flask_webcache/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from werkzeug.contrib.cache import SimpleCache
 
 from . import storage, validation, handlers, modifiers, utils, recache

--- a/flask_webcache/handlers.py
+++ b/flask_webcache/handlers.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from flask import g
 
 from . import storage, validation, modifiers

--- a/flask_webcache/modifiers.py
+++ b/flask_webcache/modifiers.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 from datetime import timedelta, datetime
 from functools import wraps
+from six import iteritems
 
 from flask import _request_ctx_stack
 from werkzeug.datastructures import ResponseCacheControl
@@ -35,11 +37,11 @@ class cache_for(BaseModifier):
 class cache_control(BaseModifier):
     "Modifier that sets arbitrary Cache-Control directives"
     def __init__(self, **kwargs):
-        for key, value in kwargs.iteritems():
+        for key, value in iteritems(kwargs):
             if not hasattr(ResponseCacheControl, key):
                 raise TypeError('%s got an unexpected keyword argument %r'
                                 % (self.__class__.__name__, key))
         self.kwargs = kwargs
     def modify_response(self, response):
-        for key, value in self.kwargs.iteritems():
+        for key, value in iteritems(self.kwargs):
             setattr(response.cache_control, key, value)

--- a/flask_webcache/recache.py
+++ b/flask_webcache/recache.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from flask import request, current_app
 from werkzeug.http import Headers
 

--- a/flask_webcache/storage.py
+++ b/flask_webcache/storage.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from datetime import datetime
 import hashlib
 
@@ -48,16 +49,16 @@ class Base(object):
         self.config = config or Config()
     def request_path_and_query(self):
         if request.query_string:
-            return '?'.join((request.path, request.query_string))
+            return '?'.join((request.path, request.query_string.decode('utf-8')))
         return request.path
     def make_key(self, *bits):
         return self.CACHE_SEPARATOR.join(bits)
     def make_response_key(self, namespace, metadata):
         ctx = hashlib.md5()
         for header in metadata.vary:
-            ctx.update(header + request.headers.get(header, ''))
-        ctx.update(metadata.salt)
-        ctx.update(self.config.master_salt)
+            ctx.update((header + request.headers.get(header, '')).encode('utf-8'))
+        ctx.update(metadata.salt.encode('utf-8'))
+        ctx.update(self.config.master_salt.encode('utf-8'))
         return self.make_key(namespace, ctx.hexdigest(),
                              self.request_path_and_query())
     def metadata_cache_key(self):

--- a/flask_webcache/utils.py
+++ b/flask_webcache/utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from random import getrandbits
 
 def make_salt(bits=128):

--- a/flask_webcache/validation.py
+++ b/flask_webcache/validation.py
@@ -1,6 +1,7 @@
+from __future__ import unicode_literals
 from datetime import datetime
 
-from httplib import NOT_IMPLEMENTED, NOT_MODIFIED, OK
+from six.moves.http_client import NOT_IMPLEMENTED, NOT_MODIFIED, OK
 import hashlib
 
 from flask import request, g

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'Flask'
+        'Flask',
+        'six'
     ],
     classifiers=[
         'Environment :: Web Environment',

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,5 +1,6 @@
+from __future__ import unicode_literals
 import unittest
-from httplib import NOT_MODIFIED
+from six.moves.http_client import NOT_MODIFIED
 
 from flask import Flask
 from flask_webcache import easy_setup

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from datetime import datetime, timedelta
 import unittest
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,8 @@
+from __future__ import unicode_literals
 import unittest
 from datetime import timedelta, datetime
-from cPickle import dumps, loads
+from six.moves.cPickle import dumps, loads
+from six import iteritems
 
 from flask import Flask, send_file
 from werkzeug.wrappers import Response
@@ -12,7 +14,7 @@ from flask_webcache.storage import (CacheMiss, NoResourceMetadata, NoMatchingRep
 from flask_webcache.recache import RECACHE_HEADER
 from flask_webcache.utils import werkzeug_cache_get_or_add
 
-from testutils import compare_numbers 
+from testutils import compare_numbers
 a = Flask(__name__)
 
 class UtilsTestCase(unittest.TestCase):
@@ -59,7 +61,7 @@ class StorageTestCase(unittest.TestCase):
     def test_cache_control_cachability(self):
         def check_response_with_cache_control(**cc):
             r = Response()
-            for k, v in cc.iteritems():
+            for k, v in iteritems(cc):
                 setattr(r.cache_control, k, v)
             return self.s.should_cache_response(r)
         with a.test_request_context():
@@ -148,7 +150,7 @@ class StorageTestCase(unittest.TestCase):
         with a.test_request_context('/foo'):
             r = Response('foo')
             self.s.cache_response(r)
-            self.assertEquals(self.r.fetch_response().data, 'foo')
+            self.assertEquals(self.r.fetch_response().data, b'foo')
             self.r.config.master_salt = 'newsalt'
             with self.assertRaises(NoMatchingRepresentation):
                 self.r.fetch_response()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from datetime import datetime
 import unittest
 
@@ -8,7 +9,7 @@ from flask_webcache.validation import Validation
 a = Flask(__name__)
 v = Validation()
 
-from testutils import compare_datetimes 
+from testutils import compare_datetimes
 
 class ValidationTestCase(unittest.TestCase):
 
@@ -42,14 +43,14 @@ class ValidationTestCase(unittest.TestCase):
         r = Response('foo')
         with a.test_request_context():
             v.return_not_modified_response(r)
-        self.assertEquals(r.data, '')
+        self.assertEquals(r.data, b'')
         self.assertEquals(r.status_code, 304)
 
     def test_not_modified_failure(self):
         r = Response('foo')
         with a.test_request_context(method='PUT'):
             v.return_not_modified_response(r)
-        self.assertEquals(r.data, 'foo')
+        self.assertEquals(r.data, b'foo')
         self.assertEquals(r.status_code, 501)
 
     def test_date_addition(self):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from datetime import timedelta
 
 def compare_datetimes(this, other, max_seconds_difference=1):


### PR DESCRIPTION
I have updated `flask-webcache` to support both Python 2.7 and Python 3.4. All tests are passing, and I have implemented the `easy_setup()` mode in my project and it seems to work.

Looking at the test code coverage, the only module not reasonably covered is `recache.py` which may or may not be working – I'm not quite sure what it is meant to do so I haven't been able to implement it in order to test manually.

This PR does not add any additional development or usage dependencies, however I think `tox` would be a good testing tool to implement. I have updated the Travis CI config to run the tests under both 2.7 and 3.4.

I'm happy to squish the commits before pulling, make any changes, etc.
